### PR TITLE
Add tests for cadence peaks zero counts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Package to calculate step and cadence metrics from timestamped acce
 License: AGPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: PhysicalActivity, RSQLite, tools, stats, utils
 Suggests: 
     testthat (>= 3.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 (Github-only release date: 2025-XX-XX)
 -   Update IDs definition removing .RData to match current GGIR versions.
-
+-   Improve peak cadence test.
+-   Improve extraction of wear time when using GGIR-processed data.
 
 # stepmetrics 0.1.2
 

--- a/R/step.metrics.R
+++ b/R/step.metrics.R
@@ -94,18 +94,22 @@ step.metrics = function(datadir, outputdir="./",
       wear.min[di] = wear.awake.perc[di] = NA
       if (isGGIR == TRUE) {
         if (di == 1) {
-          GGIRreports = dir(gsub("meta/ms2.out", "results/", datadir), recursive = T, full.names = TRUE)
-          p2file = grep("part2_daysummary.csv", GGIRreports, value = TRUE)
-          p5file = grep("QC/part5_daysummary_full_MM", GGIRreports, value = TRUE)[1]
           p2 = p5 = NULL
-          p2 = utils::read.csv(p2file)
-          if (!is.na(p5file)) p5 = utils::read.csv(p5file)
+          SUM = NULL
+          load(files2read)
+          p2 = SUM$daysummary
+          if (dir.exists(gsub("ms2.out", "ms5.out", files2read))) {
+            output = NULL
+            load(dir.exists(gsub("ms2.out", "ms5.out", files2read)))
+            p5 = output
+          }
         }
         GGIRrow = which(p2$ID == id & substr(p2$calendar_date, 1, 10) == date[di])
-        wear.min[di] = p2[GGIRrow, "N.valid.hours"]*60
+        nValidHoursCol = grep("valid.hours|valid hours", colnames(p2), value = T)
+        wear.min[di] = as.numeric(p2[GGIRrow, nValidHoursCol])*60
         GGIRrow = which(p5$ID == id & substr(p5$calendar_date, 1, 10) == date[di])
         if (length(GGIRrow) > 0) {
-          wear.awake.perc[di] = (100 - p5[GGIRrow, "nonwear_perc_day"]) / 100
+          wear.awake.perc[di] = (100 - as.numeric(p5[GGIRrow, "nonwear_perc_day"])) / 100
         }
       }
       #Steps/day

--- a/tests/testthat/test-get_cadence_peaks.R
+++ b/tests/testthat/test-get_cadence_peaks.R
@@ -13,4 +13,14 @@ test_that("calculation of cadence peaks works", {
   expect_equal(unname(peaks$values[1]), max(x$steps))
   expect_equal(unname(peaks$values[2]), mean(sort(x$steps, decreasing = TRUE)[1:30]))
   expect_equal(unname(peaks$values[3]), mean(sort(x$steps, decreasing = TRUE)[1:60]))
+
+  # check that all expected names are present
+  expected_names <- c("CAD_pk1_spm", "CAD_pk30_spm", "CAD_pk60_spm",
+                      "CAD_nZeroes_pk30", "CAD_nZeroes_pk60")
+  expect_true(all(expected_names %in% peaks$names))
+
+  # check number of zero values used for the peaks
+  expect_equal(unname(peaks$values[4]), sum(sort(x$steps, decreasing = TRUE)[1:1] == 0))
+  expect_equal(unname(peaks$values[5]), sum(sort(x$steps, decreasing = TRUE)[1:30] == 0))
+  expect_equal(unname(peaks$values[6]), sum(sort(x$steps, decreasing = TRUE)[1:60] == 0))
 })


### PR DESCRIPTION
## Summary
- test expected cadence peak names
- check zero counts in cadence peaks

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68557aad19e08332a22da410e9b723fc

## Summary by Sourcery

Enhance cadence peaks tests to verify expected output names and counts of zero values across peak windows.

Tests:
- Add assertions to check that the returned cadence peak names include both step-per-minute and zero-count fields.
- Add assertions to verify the number of zero-valued steps in the top-1, top-30, and top-60 peak calculations.