### PR TITLE
Improved definition of days when there are time gaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -   Update IDs definition removing .RData to match current GGIR versions.
 -   Improve peak cadence test.
 -   Improve extraction of wear time when using GGIR-processed data.
+-   Improve identification of day indices when there are time gaps. #17
 
 # stepmetrics 0.1.2
 

--- a/R/define_day_indices.R
+++ b/R/define_day_indices.R
@@ -1,41 +1,15 @@
-#' Define day indices from timestamp
+#' Define day indices from ISO 8601 timestamps
 #'
-#' @param ts Character (no default) with timestamps from data.
-#'
+#' @param ts Character vector of ISO 8601 timestamps (e.g., "2024-06-26T23:45:00+0100")
 #' @return Numeric vector with day indices
 #' @export
-#'
-#' @examples
-#' \dontrun{
-#' data = readFile("mydata/s01_fitbit.csv")
-#' define_day_indices(data$timestamp)
-#' }
-define_day_indices = function(ts) {
-  mnightsi = grep("00:00:00", ts, fixed = T)
-  day = rep(NA, times = length(ts))
-  if (length(mnightsi) > 1) { # loop through midnights if more than 1
-    d = 1
-    # Loop through the rest of the days
-    for (j in 1:length(mnightsi)) {
-      if (j < length(mnightsi)) {
-        if (j == 1 & mnightsi[j] > 1) {
-          day[1:mnightsi[j]] = d
-        } else if (j == 1 & mnightsi[j] == 1) {
-          next
-        } else {
-          day[mnightsi[j - 1]:mnightsi[j]] = d
-        }
-        d = d + 1
-      } else {
-        day[mnightsi[j - 1]:mnightsi[j]] = d; d = d + 1
-        day[mnightsi[j]:length(day)] = d
-      }
-    }
-  } else if (length(mnightsi) == 1) { # if only 1 midnight
-    day[1:(mnightsi - 1)] = 1
-    day[mnightsi:length(ts)] = 2
-  } else { # less of 1 day of data
-   day = rep(1, length(ts))
-  }
-  return(day)
+define_day_indices <- function(ts) {
+  # Convert to Date from ISO 8601 (safe even with time zones)
+  ts = as.POSIXct(ts, format = "%Y-%m-%dT%H:%M:%S%z")
+  dates = as.Date(ts, tz = "")
+
+  # Assign a unique day index for each date
+  day_indices = as.integer(factor(dates))
+
+  return(day_indices)
 }

--- a/man/define_day_indices.Rd
+++ b/man/define_day_indices.Rd
@@ -2,22 +2,16 @@
 % Please edit documentation in R/define_day_indices.R
 \name{define_day_indices}
 \alias{define_day_indices}
-\title{Define day indices from timestamp}
+\title{Define day indices from ISO 8601 timestamps}
 \usage{
 define_day_indices(ts)
 }
 \arguments{
-\item{ts}{Character (no default) with timestamps from data.}
+\item{ts}{Character vector of ISO 8601 timestamps (e.g., "2024-06-26T23:45:00+0100")}
 }
 \value{
 Numeric vector with day indices
 }
 \description{
-Define day indices from timestamp
-}
-\examples{
-\dontrun{
-data = readFile("mydata/s01_fitbit.csv")
-define_day_indices(data$timestamp)
-}
+Define day indices from ISO 8601 timestamps
 }


### PR DESCRIPTION
Fixes #17 => now stepmetrics is more flexible to define dates when aggregating data by date.