### PR TITLE
Minor edits to text and Rd files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stepmetrics
 Type: Package
 Title: Calculate Step and Cadence Metrics from Wearable Data
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(
     person("Jairo H", "Migueles", 
            email = "jairo@jhmigueles.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# stepmetrics 1.0.3
+
+- Tests: hardened timestamp checks to be robust across platforms (Windows, macOS ARM, Linux). 
+  Added cross-platform ISO-8601 parser that correctly handles `Z` and `hh:mm` offsets.
+- CI: added macOS ARM (Apple Silicon) checks via R-hub v2 to reproduce CRAN’s environment.
+
 # stepmetrics 1.0.2
 
 - Fix: preserve local clock time when parsing timestamps from CSV/AGD. 

--- a/R/define_day_indices.R
+++ b/R/define_day_indices.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' Converts a vector of ISO 8601 timestamps into sequential day indices
-#' (1, 2, 3, …), where each unique calendar date corresponds to a unique
+#' (1, 2, 3, ...), where each unique calendar date corresponds to a unique
 #' integer. This is useful for looping over or summarizing data by day
 #' when working with minute-level time series from wearables.
 #'

--- a/R/get_cadence_bands.R
+++ b/R/get_cadence_bands.R
@@ -12,7 +12,7 @@
 #'   element represents one minute of the day.
 #' @param bands Numeric vector of break points that define the cadence bands.
 #'   Defaults to \code{c(0, 1, 20, 40, 60, 80, 100, 120, Inf)}, which produces
-#'   the bands 0, 1–19, 20–39, 40–59, 60–79, 80–99, 100–119, and \eqn{\ge}120 spm.
+#'   the bands 0, 1-19, 20-39, 40-59, 60-79, 80-99, 100-119, and 120+ spm.
 #'
 #' @return A list with three elements:
 #' \describe{

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,6 +2,7 @@ AGD
 ActiGraph
 Barreira
 CMD
+CRAN’s
 Codecov
 Fitbit
 GGIR
@@ -14,6 +15,7 @@ POSIXct
 RData
 README
 Subfolders
+TZ
 VPA
 Verisense
 Zenodo

--- a/man/define_day_indices.Rd
+++ b/man/define_day_indices.Rd
@@ -18,7 +18,7 @@ An integer vector of the same length as `ts`, where each element
 }
 \description{
 Converts a vector of ISO 8601 timestamps into sequential day indices
-(1, 2, 3, …), where each unique calendar date corresponds to a unique
+(1, 2, 3, ...), where each unique calendar date corresponds to a unique
 integer. This is useful for looping over or summarizing data by day
 when working with minute-level time series from wearables.
 }

--- a/man/get_cadence_bands.Rd
+++ b/man/get_cadence_bands.Rd
@@ -12,7 +12,7 @@ element represents one minute of the day.}
 
 \item{bands}{Numeric vector of break points that define the cadence bands.
 Defaults to \code{c(0, 1, 20, 40, 60, 80, 100, 120, Inf)}, which produces
-the bands 0, 1–19, 20–39, 40–59, 60–79, 80–99, 100–119, and \eqn{\ge}120 spm.}
+the bands 0, 1-19, 20-39, 40-59, 60-79, 80-99, 100-119, and 120+ spm.}
 }
 \value{
 A list with three elements:


### PR DESCRIPTION
## Summary by Sourcery

Harden timestamp parsing tests by adding locale isolation and precise ISO-8601 parsing, update release notes, extend CI to macOS ARM, and refine documentation wording

Enhancements:
- Add locale isolation in tests to ensure consistent timestamp formatting across platforms

CI:
- Add macOS ARM (Apple Silicon) checks via R-hub v2 to CI

Documentation:
- Update NEWS.md with 1.0.3 release notes for hardened timestamp checks
- Standardize hyphenation and punctuation in R script and Rd documentation files

Tests:
- Introduce is.ISO8601 and parse_iso_utc helpers and replace broad regex checks with precise POSIXct comparisons
- Replace expect_true with expect_equal and expect_identical for timestamp and step count validations