### PR TITLE
idloc default changed to NULL and improved file matching in GGIR output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stepmetrics
 Type: Package
 Title: Calculate Step and Cadence Metrics from Wearable Data
-Version: 1.0.3
+Version: 1.1.0.9000
 Authors@R: c(
     person("Jairo H", "Migueles", 
            email = "jairo@jhmigueles.com", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stepmetrics
 Type: Package
 Title: Calculate Step and Cadence Metrics from Wearable Data
-Version: 1.1.0.9000
+Version: 1.1.0
 Authors@R: c(
     person("Jairo H", "Migueles", 
            email = "jairo@jhmigueles.com", 
@@ -24,7 +24,7 @@ Description: Provides functions to calculate step- and cadence-based metrics fro
 License: AGPL (>= 3)
 Depends: R (>= 3.5.0)
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports: 
     PhysicalActivity,
     tools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # stepmetrics 1.1.0
 
-- Features: Added support for idloc = NULL, i.e., the entire file basename  is used as ID.
-- Fix: Resolved file matching failure for GGIR output when IDs contain regex special characters (e.g., (, ), .)
+- Features: Added support for idloc = NULL, i.e., the entire file basename is used as ID.
+- Fix: Resolved file matching failure for GGIR output when IDs (now GGIR-identified ID is used)
 
 # stepmetrics 1.0.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# stepmetrics 1.1.0
+
+- Features: Added support for idloc = NULL, i.e., the entire file basename  is used as ID.
+- Fix: Resolved file matching failure for GGIR output when IDs contain regex special characters (e.g., (, ), .)
+
 # stepmetrics 1.0.3
 
 - Tests: hardened timestamp checks to be robust across platforms (Windows, macOS ARM, Linux). 

--- a/R/readFile.R
+++ b/R/readFile.R
@@ -118,6 +118,7 @@ readFile = function(path, time_format = c(), tz = "") {
   # handle multiple files per participant
   AllFiles = path
   file = path[1]
+  id = NULL # if GGIR, this would be overrided with SUM$summary$ID
 
   # identify file extension
   format = tools::file_ext(file)
@@ -252,6 +253,7 @@ readFile = function(path, time_format = c(), tz = "") {
     IMP = c()
     load(file)
     data = IMP$metashort
+    id = unique(SUM$summary$ID)
   }
 
   # set up object to return ----
@@ -319,5 +321,6 @@ readFile = function(path, time_format = c(), tz = "") {
   if (epoch > 60) stop("This package cannot work with epoch lengths longer than 60 seconds for now.")
 
   # return
-  return(cleanData)
+  return(list(data = cleanData,
+              id = id))
 }

--- a/R/step.metrics.R
+++ b/R/step.metrics.R
@@ -104,8 +104,10 @@ step.metrics = function(datadir, outputdir="./",
 
   # Get IDs -----
   ids = c()
-  if (is.null(idloc)) {
-    # Use the full file name as the ID
+  # identify ids as a way to detect if any recording is splitted in several files
+  if (is.null(idloc) || isGGIR) {
+    # Use the full file name as the ID if no idloc specified or if GGIR 
+    #   (ID will be derived from GGIR milestone file)
     ids = files
   } else {
     for (i in 1:length(files)) {
@@ -125,12 +127,13 @@ step.metrics = function(datadir, outputdir="./",
   }
 
   #Loop through the files
-  if (verbose == TRUE) cat("Processing participant: ")
   for (i in 1:length(ids)) {
-    if (verbose == TRUE) cat(paste0(ids[i], " "))
+    if (verbose == TRUE) cat(paste0("\rRecording ", i, "/", length(ids), ": ", ids[i]))
     # read data ----
     files2read = grep(ids[i], files_fn, value = TRUE, fixed = TRUE)
     data = readFile(files2read, time_format = time_format)
+    id_ggir = data$id
+    data = data$data
 
     # create vector with day indices -----
     day = define_day_indices(data$timestamp)
@@ -139,7 +142,11 @@ step.metrics = function(datadir, outputdir="./",
     for (di in 1:length(unique(day))) {
 
       # ID
-      id = ids[i]
+      if (isGGIR) {
+        id = id_ggir
+      } else {
+        id = ids[i]
+      }
 
       #Date
       if (di == 1) date = wday = wday_num = c()
@@ -270,9 +277,9 @@ step.metrics = function(datadir, outputdir="./",
   colnames(output) = names.out.2
 
   #Loop through files to calculate mean variables
-  if (verbose == TRUE) cat("Processing participant: ")
   for (i in 1:length(files)) {
-    if (verbose == TRUE) cat(gsub("_DaySum.csv", "", files[i]), " ")
+    if (verbose == TRUE) cat(paste0("\rID ", i, "/", length(files), ": ", 
+                                    gsub("_DaySum.csv", "", files[i])))
     D = read.csv(paste0(outputdir,"/daySummary/", files[i]))
     if (isGGIR == TRUE) {
       if (is.null(includeawakecrit)) {

--- a/R/step.metrics.R
+++ b/R/step.metrics.R
@@ -23,7 +23,7 @@
 #'   `meta/ms2.out/`.
 #' @param outputdir Character. Directory where results should be stored.
 #'   Subfolders will be created as needed (`daySummary/`).
-#' @param idloc Character (default = `"_"`). Delimiter used to extract
+#' @param idloc Character (default = NULL). Delimiter used to extract
 #'   participant IDs from filenames (ID is expected before this string).
 #' @param cadence_bands Numeric vector (default =
 #'   `c(0, 1, 20, 40, 60, 80, 100, 120, Inf)`).
@@ -81,7 +81,7 @@
 #' @importFrom utils write.csv
 #' @export
 step.metrics = function(datadir, outputdir="./",
-                        idloc = "_",
+                        idloc = NULL,
                         cadence_bands = c(0, 1, 20, 40, 60, 80, 100, 120, Inf),
                         cadence_peaks = c(1, 30, 60),
                         cadence_MOD = 100,
@@ -104,10 +104,18 @@ step.metrics = function(datadir, outputdir="./",
 
   # Get IDs -----
   ids = c()
-  for (i in 1:length(files)) {
-    ids[i] = unlist(strsplit(files[i], split = idloc, fixed = TRUE))[1]
+  if (is.null(idloc)) {
+    # Use the full file name as the ID
+    ids = files
+  } else {
+    for (i in 1:length(files)) {
+      # Use the provided idloc delimiter
+      ids[i] = unlist(strsplit(files[i], split = idloc, fixed = TRUE))[1]
+    }
   }
   ids = unique(ids)
+
+  # This handles the removal of the .RData extension from GGIR files
   ids = gsub(".RData$", "", ids)
 
   if (verbose == TRUE) {
@@ -121,7 +129,7 @@ step.metrics = function(datadir, outputdir="./",
   for (i in 1:length(ids)) {
     if (verbose == TRUE) cat(paste0(ids[i], " "))
     # read data ----
-    files2read = grep(ids[i], files_fn, value = TRUE)
+    files2read = grep(ids[i], files_fn, value = TRUE, fixed = TRUE)
     data = readFile(files2read, time_format = time_format)
 
     # create vector with day indices -----

--- a/R/step.metrics.R
+++ b/R/step.metrics.R
@@ -25,6 +25,8 @@
 #'   Subfolders will be created as needed (`daySummary/`).
 #' @param idloc Character (default = NULL). Delimiter used to extract
 #'   participant IDs from filenames (ID is expected before this string).
+#'   If working with GGIR output, `idloc` is ignored and the GGIR-identified
+#'   ID is directly used to ensure matching. 
 #' @param cadence_bands Numeric vector (default =
 #'   `c(0, 1, 20, 40, 60, 80, 100, 120, Inf)`).
 #'   Breakpoints (in steps/min) used to compute time and steps per cadence band.

--- a/man/step.metrics.Rd
+++ b/man/step.metrics.Rd
@@ -7,7 +7,7 @@
 step.metrics(
   datadir,
   outputdir = "./",
-  idloc = "_",
+  idloc = NULL,
   cadence_bands = c(0, 1, 20, 40, 60, 80, 100, 120, Inf),
   cadence_peaks = c(1, 30, 60),
   cadence_MOD = 100,
@@ -30,7 +30,7 @@ starts with `"output_"`); the function will then look inside
 \item{outputdir}{Character. Directory where results should be stored.
 Subfolders will be created as needed (`daySummary/`).}
 
-\item{idloc}{Character (default = `"_"`). Delimiter used to extract
+\item{idloc}{Character (default = NULL). Delimiter used to extract
 participant IDs from filenames (ID is expected before this string).}
 
 \item{cadence_bands}{Numeric vector (default =

--- a/man/step.metrics.Rd
+++ b/man/step.metrics.Rd
@@ -31,7 +31,9 @@ starts with `"output_"`); the function will then look inside
 Subfolders will be created as needed (`daySummary/`).}
 
 \item{idloc}{Character (default = NULL). Delimiter used to extract
-participant IDs from filenames (ID is expected before this string).}
+participant IDs from filenames (ID is expected before this string).
+If working with GGIR output, `idloc` is ignored and the GGIR-identified
+ID is directly used to ensure matching.}
 
 \item{cadence_bands}{Numeric vector (default =
 `c(0, 1, 20, 40, 60, 80, 100, 120, Inf)`).

--- a/tests/testthat/test-get_cadence_bands.R
+++ b/tests/testthat/test-get_cadence_bands.R
@@ -3,6 +3,7 @@ test_that("calculation of cadence bands works", {
   # we use the testfile: fitbit -----
   paths = dir(system.file("extdata","testfiles_fitbit/", package = "stepmetrics"), full.names = TRUE)
   x = readFile(paths)
+  x = x$data
 
   # tests -----------
   bands_to_calculate = c(0, 1, 20, 40, 60, 80, 100, 120, Inf)

--- a/tests/testthat/test-get_cadence_peaks.R
+++ b/tests/testthat/test-get_cadence_peaks.R
@@ -3,6 +3,7 @@ test_that("calculation of cadence peaks works", {
   # we use the testfile: fitbit -----
   paths = dir(system.file("extdata", "testfiles_fitbit/", package = "stepmetrics"), full.names = TRUE)
   x = readFile(paths)
+  x = x$data
 
   # tests -----------
   peaks_to_calculate = c(1, 30, 60)

--- a/tests/testthat/test-readFile.R
+++ b/tests/testthat/test-readFile.R
@@ -2,6 +2,7 @@ test_that("reads and formats data correctly", {
   testthat::skip_if_not_installed("RSQLite")
 
   withr::local_locale(c(LC_TIME = "C", LC_COLLATE = "C"))
+  withr::local_timezone("UTC")
 
   # ISO-8601 checker
   is.ISO8601 <- function(x) {
@@ -36,6 +37,7 @@ test_that("reads and formats data correctly", {
             system.file("extdata/testfiles_fitbit/S001_d2_1min_epoch.csv", package = "stepmetrics"),
             system.file("extdata/testfiles_fitbit/S001_d3_1min_epoch.csv", package = "stepmetrics"))
   data1 = readFile(file1)
+  data1 = data1$data
 
   expect_equal(dim(data1), c(1440*3, 2))
   expect_equal(colnames(data1), c("timestamp", "steps"))
@@ -54,7 +56,8 @@ test_that("reads and formats data correctly", {
 
   # 30 sec epoch
   data3 = readFile(file3)
-
+  data3 = data3$data
+  
   expect_equal(dim(data3), c(4882, 2))
   expect_equal(colnames(data3), c("timestamp", "steps"))
   expect_true(is.ISO8601(data3$timestamp[1]))
@@ -68,7 +71,8 @@ test_that("reads and formats data correctly", {
 
   # with header / timestamp
   data4 = readFile(file4)
-
+  data4 = data4$data
+  
   expect_equal(dim(data4), dim(data3))
   expect_equal(data4[1, 1], data3[1, 1])
   expect_equal(data4[1, 2], data3[1, 2])
@@ -78,7 +82,8 @@ test_that("reads and formats data correctly", {
 
   # without header / timestamp
   data5 = readFile(file5)
-
+  data5 = data5$data
+  
   expect_equal(dim(data5), dim(data4))
   expect_equal(data5[1, 1], data4[1, 1])
   expect_equal(data5[1, 2], data4[1, 2])
@@ -87,7 +92,8 @@ test_that("reads and formats data correctly", {
 
   # semicolon separated csv
   data6 = readFile(file6)
-
+  data6 = data6$data
+  
   expect_equal(dim(data6), dim(data5))
   expect_equal(data6[1, 1], data5[1, 1])
   expect_equal(data6[1, 2], data5[1, 2])
@@ -96,7 +102,8 @@ test_that("reads and formats data correctly", {
 
   # one-row header and separated date-time
   data7 = readFile(file7)
-
+  data7 = data7$data
+  
   ts  <- parse_iso_utc(data7$timestamp[1])
   exp <- as.POSIXct("2021-07-03 13:48:00", tz = "UTC")
   expect_false(is.na(ts))
@@ -109,7 +116,8 @@ test_that("reads and formats data correctly", {
   file8 = system.file("extdata/testfiles_GGIR/output_test/meta/ms2.out/101_1.gt3x.RData",
                       package = "stepmetrics")
   data8 = readFile(file8)
-
+  data8 = data8$data
+  
   expect_equal(dim(data8), c(13635, 2))
   expect_true(grepl("19:00:00", data8[1, 1],))
   expect_equal(range(data8[, 2]), c(0, 121))

--- a/tests/testthat/test-step.R
+++ b/tests/testthat/test-step.R
@@ -11,7 +11,7 @@ test_that("step.metrics produces output", {
   out1 <- mkdtemp()
   on.exit(unlink(out1, recursive = TRUE, force = TRUE), add = TRUE)
 
-  step.metrics(datadir = datadir1, outputdir = out1)
+  step.metrics(datadir = datadir1, outputdir = out1, idloc = "_")
 
   expect_true(dir.exists(out1))
   expect_true(dir.exists(file.path(out1, "daySummary")))


### PR DESCRIPTION
Improve ID handling and integration with GGIR

Fixes #28 
Fixes #29 

## Summary by Sourcery

Allow step.metrics to use full filenames as IDs when idloc is NULL and improve file matching by using fixed string matching

New Features:
- Support idloc = NULL to use the full file basename as the participant ID

Bug Fixes:
- Use fixed string matching in grep to correctly handle GGIR filenames with special characters

Enhancements:
- Strip .RData extension from IDs after extraction

Documentation:
- Update default idloc value and related description in the documentation and NEWS